### PR TITLE
[OAS-14]: Trigger CI on push

### DIFF
--- a/ci/codebuild.cf
+++ b/ci/codebuild.cf
@@ -55,6 +55,8 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: !Ref ComputeType
       ServiceRole: !Ref CodeBuildRole
+      Triggers:
+        Webhook: yes
       Source:
         Type: !Ref RepositoryType
         Location: !Ref RepositoryURL
@@ -87,7 +89,6 @@ Resources:
             Resource: "*"
       Roles: 
           - Ref: "CodeBuildRole"
-
 
 Outputs:
   CodeBuildURL:


### PR DESCRIPTION
Add webhook trigger.

Tested it on personal AWS account and with a personal repo and worked.

Note: This may need to be modified later on the following steps for integrating it with codepipeline.