### PR TITLE
Remove personal access token, add validate policy

### DIFF
--- a/ci/codebuild.cf
+++ b/ci/codebuild.cf
@@ -21,10 +21,6 @@ Parameters:
       - GITHUB_ENTERPRISE
       - BITBUCKET
       - S3
-  PersonalAccessToken:
-    Type: String
-    Description: "GIT personal access token"
-    NoEcho: true
   EnvironmentImage:
     Type: String
     Description: "Image to use for running a container where the build will execute"
@@ -62,7 +58,6 @@ Resources:
         Location: !Ref RepositoryURL
         Auth:
           Type: OAUTH
-          Resource: !Ref PersonalAccessToken
         BuildSpec: !Ref BuildSpecLocation
   CodeBuildRole:
     Type: AWS::IAM::Role
@@ -86,6 +81,7 @@ Resources:
               - "logs:CreateLogGroup"
               - "logs:CreateLogStream"
               - "logs:PutLogEvents"
+              - "cloudformation:ValidateTemplate"
             Resource: "*"
       Roles: 
           - Ref: "CodeBuildRole"


### PR DESCRIPTION
It turns out that the user this is authorized as,
modus-jenkins, must be an administrator of the GitHub project
when this template is applied, as it needs permission to create
the webhook.

See: https://stackoverflow.com/questions/47529302/unable-to-create-aws-codebuild-webhook