### PR TITLE
fix monitor events

### DIFF
--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -672,6 +672,7 @@ const monitorStackProgress = async (id, token) => {
   let in_progress = true;
   let events_seen = []
   let spinner = new Spinner();
+  spinner.setSpinnerDelay(6);
   spinner.setSpinnerString('|/-\\');
   logIfVerbose(`Start monitoring stack ${id}`);
   spinner.start();

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -636,9 +636,12 @@ const getStackEvents = async (id) => {
   }
 
   let nestedStackIds = events.reduce((list, e) => {
+    let physical_resource_id = e.PhysicalResourceId;
     if (e.ResourceType === 'AWS::CloudFormation::Stack' &&
-        e.PhysicalResourceId != '' && e.StackId != e.PhysicalResourceId) {
-      list.push(e.StackId);
+        physical_resource_id != '' &&
+        e.StackId != physical_resource_id &&
+        !list.includes(physical_resource_id)) {
+      list.push(physical_resource_id);
     }
     return list;
   }, []);

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -419,12 +419,12 @@ const getStackEventColor = (state) => {
  *
  * @return {String} output_line
  */
-const getStackEventOutputLine = (e) => {
+const printStackEventOutputLine = (e) => {
   let time = `${e.Timestamp.toLocaleString()}`;
   let status = `${chalk[getStackEventColor(e.ResourceStatus)](e.ResourceStatus)}`;
   let resource = `${e.ResourceType}`;
   let id = `${e.PhysicalResourceId}`;
-  return `${time} ${status} ${resource} ${id}`;
+  console.log(`${time} ${status} ${resource} ${id}`);
 }
 
 /**
@@ -696,10 +696,7 @@ const monitorStackProgress = async (id, token) => {
         logIfVerbose(`Event ignored: ${e.EventId}`);
       } else {
         logIfVerbose(`NEW Event: ${e}`);
-        spinner.text = getStackEventOutputLine(e);
-        if (e.ResourceStatusReason !== 'User Initiated') {
-          process.stdout.write('\n');
-        }
+        printStackEventOutputLine(e);
         events_seen.push(e.EventId);
       }
       if (e.ResourceType === 'AWS::CloudFormation::Stack' &&

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -672,7 +672,6 @@ const monitorStackProgress = async (id, token) => {
   let in_progress = true;
   let events_seen = []
   let spinner = new Spinner();
-  spinner.setSpinnerDelay(6);
   spinner.setSpinnerString('|/-\\');
   logIfVerbose(`Start monitoring stack ${id}`);
   spinner.start();

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -711,11 +711,10 @@ const monitorStackProgress = async (id, token) => {
       }
       last_time = e.Timestamp;
     }
-    if (in_progress) {
-      await delay(1000);
-    }
+    await delay(1000);
   }
   spinner.stop();
+  process.stdout.write('\n');
   logIfVerbose(`End monitoring stack ${id} with token ${token}`);
 }
 

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -57,7 +57,9 @@ const error_states = [
   'DELETE_FAILED',
   'UPDATE_FAILED',
   'ROLLBACK_FAILED',
-  'UPDATE_ROLLBACK_FAILED'
+  'UPDATE_ROLLBACK_FAILED',
+  'UPDATE_ROLLBACK_IN_PROGRESS',
+  'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS'
 ];
 
 const paths = {
@@ -1324,6 +1326,5 @@ const processConfiguration = async () => {
   if (commander.args.includes('ci')) {
     await ciCmds(type)
   }
-
 
 })();

--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -629,8 +629,9 @@ const getNextStackEvent = async (id, next) => {
 const getStackEvents = async (id) => {
   let response = await getNextStackEvent(id);
   let events = response.StackEvents;
+
   while (typeof response.NextToken !== 'undefined') {
-    response = await getNextStackEvent(id);
+    response = await getNextStackEvent(id, response.NextToken);
     events.concat(response.StackEvents);
   }
 


### PR DESCRIPTION
- Add missing next token to `getNextStackEvents`
- Ensure all child stacks are added to the list of stacks to monitor
- Fix monitoring to display latest status
- Move event printing out of spinner to avoid losing multiple simultaneous events.
- Move the event print to its own function (This will require to adjust the line to the terminal width)
- Add missing events to the error list to print them in red.

Issue related: #37