### PR TITLE
Fix short CLI options

### DIFF
--- a/bin/capsule.js
+++ b/bin/capsule.js
@@ -199,8 +199,8 @@ commander
   .option('-c, --config <config-path>', 'Load the configuration from the specified path')
   .option('-p, --aws-profile <profile>', 'The AWS profile to use')
   .option('-u, --url <repo>', 'The source control URL to use')
-  .option('-sc, --site_config <site-config>', 'A JSON object contianing site configuration, overrides values defined in site config file')
-  .option('-scf, --site_config_file <site-config-path>', 'Custom configuration file used in CodeBuild for building the static site')
+  .option('-j, --site_config <site-config>', 'A JSON object contianing site configuration, overrides values defined in site config file')
+  .option('-f, --site_config_file <site-config-path>', 'Custom configuration file used in CodeBuild for building the static site')
   .action(function (type, options) {
     console.log("Executing create for: "+type)
     commander.type = options._name || undefined
@@ -223,8 +223,8 @@ commander
   .option('-c, --config <config-path>', 'Load the configuration from the specified path')
   .option('-p, --aws-profile <profile>', 'The AWS profile to use')
   .option('-u, --url <repo>', 'The source control URL to use')
-  .option('-sc, --site_config <site-config>', 'A JSON object contianing site configuration, overrides values defined in site config file')
-  .option('-scf, --site_config_file <site-config-path>', 'Custom configuration file used in CodeBuild for building the static site')
+  .option('-j, --site_config <site-config>', 'A JSON object contianing site configuration, overrides values defined in site config file')
+  .option('-f, --site_config_file <site-config-path>', 'Custom configuration file used in CodeBuild for building the static site')
   .action(function (type, options) {
     console.log("Executing update for: "+type)
     commander.type = options._name || undefined


### PR DESCRIPTION
When using multiple letters in short format of options, `commander` actually looks for options named per letter and raises a flag for each of those letters - https://github.com/tj/commander.js#options

`scf` option did not work since `commander` parses it like this: `-s -c -f`, and then throws an error because `-f` does not exist.

To fix this, I've added single letter short options. I wasn't too imaginative with letter choice though, please comment if you think of better naming.

